### PR TITLE
build: add third_party/docs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/langgraph"]
 	path = third_party/langgraph
 	url = https://github.com/langchain-ai/langgraph
+[submodule "third_party/docs"]
+	path = third_party/docs
+	url = https://github.com/langchain-ai/docs


### PR DESCRIPTION
## 📝 Description
- Added `langchain-ai/docs` as a git submodule located at `third_party/docs`.
- This enables local documentation development and ensures the project stays synchronized with the upstream documentation repository.

## 🧪 How Has This Been Tested?
- [ ] Added new unit/integration tests
- [ ] Verified existing tests pass
- [x] Manual testing 

> _Steps to reproduce/test:_ 
> 1. Run `git submodule update --init --recursive` to verify the module is correctly linked.

## 🏷️ Type of Change
- [ ] **feat:** A new feature (MINOR version bump)
- [ ] **fix:** A bug fix (PATCH version bump)
- [ ] **refactor:** A code change that neither fixes a bug nor adds a feature
- [ ] **perf:** A code change that improves performance
- [ ] **docs:** Documentation only changes
- [ ] **style:** Changes that do not affect the meaning of the code
- [ ] **test:** Adding missing tests or correcting existing tests
- [x] **chore:** Changes to the build process, CI/CD, or auxiliary tools

## 💥 Breaking Changes
- [x] **No**
- [ ] **Yes** 

## ✅ Developer Checklist
- [x] My PR title strictly follows `<type>[optional scope]: <description>`.
- [x] This PR contains a **single responsibility**.
- [x] I have performed a self-review of my own code.
- [x] I have added/updated tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] All markdown lists in this description strictly use `-` instead of `*`.