### PR TITLE
chore: remove langgraph submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party/langgraph"]
-	path = third_party/langgraph
-	url = https://github.com/langchain-ai/langgraph
 [submodule "third_party/docs"]
 	path = third_party/docs
 	url = https://github.com/langchain-ai/docs


### PR DESCRIPTION
## 📝 Description
- Removed the `langgraph` submodule from the project.
- Deleted the corresponding entry in `.gitmodules`.

**Why:**
- The `langgraph` submodule is no longer required for the project's current architecture.

## 🧪 How Has This Been Tested?
- [x] Verified existing tests pass
- [x] Manual testing

## 🏷️ Type of Change
- [x] **chore:** Changes to the build process, CI/CD, or auxiliary tools

## 💥 Breaking Changes
- [x] **No**

## ✅ Developer Checklist
- [x] My PR title strictly follows `<type>[optional scope]: <description>`.
- [x] This PR contains a **single responsibility**.
- [x] I have performed a self-review of my own code.
- [x] I have added/updated tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] All markdown lists in this description strictly use `-` instead of `*`.