### PR TITLE
feat: refactor benchmarking to use langfuse experiments

### DIFF
--- a/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/__main__.py
+++ b/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/__main__.py
@@ -6,6 +6,7 @@ import structlog
 from matrixcurator_benchmark.setup import bootstrap_environment
 from matrixcurator_benchmark.tools import run_tools_benchmarks
 from matrixcurator_benchmark.retrieval import run_retrieval_benchmarks
+from matrixcurator_benchmark.agents import run_agents_benchmarks
 
 logger = structlog.get_logger(__name__)
 
@@ -31,7 +32,7 @@ async def run_main():
         help="Number of concurrent workers (default: 4)",
     )
     parser.add_argument(
-        "args", nargs="*", help="Target suites to run (e.g. tools, retrieval)"
+        "args", nargs="*", help="Target suites to run (e.g. tools, retrieval, agents)"
     )
 
     args = parser.parse_args()
@@ -56,6 +57,9 @@ async def run_main():
         
     if "retrieval" in targets:
         await run_retrieval_benchmarks(limit=args.limit, workers=args.workers, docs_dict=docs_dict)
+        
+    if "agents" in targets:
+        await run_agents_benchmarks(limit=args.limit, workers=args.workers, docs_dict=docs_dict)
 
     lf = langfuse.Langfuse()
     lf.flush()

--- a/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/agents.py
+++ b/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/agents.py
@@ -1,16 +1,20 @@
-# src/benchmark/benchmark_agents.py
 import json
 import pandas as pd
-from lume import structlog
+import structlog
+from typing import Any, Dict
+import functools
 
-from matrixcurator_benchmark.core.decorators import benchmark, parametrize, fixture
-from matrixcurator_benchmark.core.exceptions import FailBenchmark
+from matrixcurator_benchmark.services import run_dataset_benchmark
+from matrixcurator_benchmark.exceptions import FailBenchmark
 
 from matrixcurator.config.main import (
     settings,
     OrchestrationStrategy,
     IntelligenceStrategy,
     ContextStrategy,
+    orchestration_strategy_var,
+    intelligence_strategy_var,
+    context_strategy_var,
 )
 from matrixcurator.modules.graph import build_graph
 
@@ -30,34 +34,48 @@ PERMUTATIONS = [
 ]
 
 
-@fixture(scope="session")
-def docs_dict(df_docs: pd.DataFrame):
-    if "id" in df_docs.columns:
-        return df_docs.set_index("id").to_dict(orient="index")
-    return {}
-
-
-@benchmark(dataset_name="character_states")
-@parametrize("routing, intelligence", PERMUTATIONS)
-async def benchmark_agents(
-    dataset_item, routing, intelligence, docs_dict, langfuse_trace
-):
-    from matrixcurator.config.main import (
-        orchestration_strategy_var,
-        intelligence_strategy_var,
-        context_strategy_var,
-    )
-    
+async def agent_task(
+    *, 
+    item: Any, 
+    routing: str, 
+    intelligence: str, 
+    docs_dict: Dict[str, Any],
+    **kwargs
+) -> str:
     # Override settings for the duration of this run using ContextVar
     orchestration_strategy_var.set(routing)
     intelligence_strategy_var.set(intelligence)
     context_strategy_var.set(ContextStrategy.FULL_CONTEXT)
 
-    input_data = dataset_item.input
-    document_id = input_data.get("document_id")
-    character_index = input_data.get("character_index", 1)
+    input_data = item.input
+    
+    document_id = None
+    character_index = 1
+    pages = None
+    
+    if isinstance(input_data, dict):
+        document_id = input_data.get("document_id")
+        character_index = input_data.get("character_index", 1)
+        pages = input_data.get("pages")
+    elif hasattr(input_data, "document_id"):
+        document_id = getattr(input_data, "document_id", None)
+        character_index = getattr(input_data, "character_index", 1)
+        pages = getattr(input_data, "pages", None)
+    elif isinstance(input_data, str):
+        try:
+            parsed = json.loads(input_data)
+            if isinstance(parsed, dict):
+                document_id = parsed.get("document_id")
+                character_index = parsed.get("character_index", 1)
+                pages = parsed.get("pages")
+        except Exception:
+            pass
+
+    doc_row = docs_dict.get(document_id)
+    if not doc_row:
+        raise ValueError(f"Document {document_id} not found in parquet data")
+
     if not pages or (hasattr(pages, "__len__") and len(pages) == 0):
-        # Resolve all available pages from the parsed text
         pre_parsed_text = doc_row.get("text")
         if isinstance(pre_parsed_text, str):
             try:
@@ -77,7 +95,6 @@ async def benchmark_agents(
                 parses = []
                 
         for parse_obj in parses:
-            # We don't filter by parser in agents.py, just aggregate all known pages across parsers
             parsed_pages = parse_obj.get("pages") or []
             for pg in parsed_pages:
                 if isinstance(pg, dict) and pg.get("page") is not None:
@@ -88,20 +105,15 @@ async def benchmark_agents(
         else:
             pages = [1]
 
-    doc_row = docs_dict.get(document_id)
-    if not doc_row:
-        raise FailBenchmark(f"Document {document_id} not found in parquet data")
-
     file_bytes = doc_row.get("file_bytes")
     filename = doc_row.get("filename", f"doc_{document_id}.pdf")
 
-    # Initialize state
     initial_state = {
         "document": {
             "file_bytes": file_bytes,
             "filename": filename,
             "status": "pending",
-            "inferred_pages": pages,  # Use the explicit pages from the dataset
+            "inferred_pages": pages,
             "total_characters": character_index,
             "discovery_confidence": 0.99,
         },
@@ -121,10 +133,9 @@ async def benchmark_agents(
 
     final_state = await graph.ainvoke(
         initial_state,
-        config={"configurable": {"thread_id": f"benchmark-{dataset_item.id}"}},
+        config={"configurable": {"thread_id": f"benchmark-{getattr(item, 'id', 'unknown')}"}},
     )
 
-    # Extract the resulting states for the requested character
     attempts = final_state.get("characters", {}).get(str(character_index), [])
     if attempts:
         latest = attempts[-1]
@@ -132,6 +143,18 @@ async def benchmark_agents(
             "character": latest.get("character"),
             "states": latest.get("states"),
         }
-        langfuse_trace(json.dumps(extracted_data))
+        return json.dumps(extracted_data)
     else:
-        langfuse_trace("{}")
+        return "{}"
+
+
+async def run_agents_benchmarks(limit: int, workers: int, docs_dict: Dict[str, Any]) -> None:
+    for routing, intelligence in PERMUTATIONS:
+        run_name = f"benchmark_agent_{routing.value}_{intelligence.value}"
+        await run_dataset_benchmark(
+            dataset_name="character_states",
+            run_name=run_name,
+            task_fn=functools.partial(agent_task, routing=routing, intelligence=intelligence, docs_dict=docs_dict),
+            limit=limit,
+            workers=workers
+        )

--- a/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/retrieval.py
+++ b/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/retrieval.py
@@ -1,11 +1,11 @@
-from typing import Any, Optional, Set
+import json
+from typing import Any, Optional, Set, Dict
 import structlog
 import functools
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from matrixcurator_benchmark.exceptions import FailBenchmark, SkipBenchmark
 from matrixcurator_benchmark.services import run_dataset_benchmark
 from matrixcurator.modules.retrieval.services import retrieve_context
 from matrixcurator.modules.retrieval.repositories import sqlite
@@ -25,92 +25,89 @@ def _get_valid_document_ids_for_parser(parser_name: str) -> Optional[Set[str]]:
         return set(result) if result else None
 
 
-async def _execute_retrieval_benchmark(
-    item: Any,
-    trace: Any,
-    parser_name: str,
-    valid_docs_per_parser: dict[str, set[str] | None],
-) -> None:
+def filter_retrieval_items(item: Any, parser_name: str, valid_docs_per_parser: Dict[str, Optional[Set[str]]]) -> bool:
     input_data = item.input
-    character_index = input_data.get("character_index", 1)
+    
+    document_id = None
+    if isinstance(input_data, dict):
+        document_id = input_data.get("document_id")
+    elif hasattr(input_data, "document_id"):
+        document_id = getattr(input_data, "document_id", None)
+    elif isinstance(input_data, str):
+        try:
+            parsed = json.loads(input_data)
+            if isinstance(parsed, dict):
+                document_id = parsed.get("document_id")
+        except Exception:
+            pass
 
-    character = input_data.get("character", {})
-    char_name = character.get("name")
+    if not document_id:
+        return False
+        
+    document_id = str(document_id)
+    valid_docs = valid_docs_per_parser.get(parser_name)
+    if valid_docs is not None and document_id not in valid_docs:
+        return False
+        
+    return True
+
+
+async def retrieval_task(*, item: Any, parser_name: str, **kwargs) -> Any:
+    input_data = item.input
+    
+    character_index = 1
+    char_name = None
+    document_id = None
+    
+    if isinstance(input_data, dict):
+        character_index = input_data.get("character_index", 1)
+        character = input_data.get("character", {})
+        char_name = character.get("name")
+        document_id = str(input_data.get("document_id"))
+    elif hasattr(input_data, "document_id"):
+        character_index = getattr(input_data, "character_index", 1)
+        character = getattr(input_data, "character", {})
+        char_name = character.get("name")
+        document_id = str(getattr(input_data, "document_id"))
+    elif isinstance(input_data, str):
+        try:
+            parsed = json.loads(input_data)
+            if isinstance(parsed, dict):
+                character_index = parsed.get("character_index", 1)
+                character = parsed.get("character", {})
+                char_name = character.get("name")
+                document_id = str(parsed.get("document_id"))
+        except Exception:
+            pass
 
     if char_name:
         query = f"Character {character_index}: {char_name}"
     else:
         query = f"Character {character_index}"
 
-    document_id = str(input_data.get("document_id"))
-
     if not document_id:
-        raise FailBenchmark("No document ID provided in input.")
-
-    valid_docs = valid_docs_per_parser.get(parser_name)
-    if valid_docs is not None and document_id not in valid_docs:
-        raise SkipBenchmark(
-            f"Document {document_id} has no vectorized chunks for {parser_name}."
-        )
+        raise ValueError("No document ID provided in input.")
 
     logger.debug(f"Retrieving context for {query} using parser {parser_name}")
     retrieved_context = await retrieve_context(
         query=query, document_id=document_id, parser_name=parser_name
     )
 
-    trace.update(output=retrieved_context)
+    return retrieved_context
 
 
-async def process_retrieval_docling(item: Any, trace: Any, valid_docs_per_parser: dict[str, set[str] | None]) -> None:
-    await _execute_retrieval_benchmark(item, trace, "docling", valid_docs_per_parser)
-
-
-async def process_retrieval_pymupdf(item: Any, trace: Any, valid_docs_per_parser: dict[str, set[str] | None]) -> None:
-    await _execute_retrieval_benchmark(item, trace, "pymupdf", valid_docs_per_parser)
-
-
-async def process_retrieval_docx(item: Any, trace: Any, valid_docs_per_parser: dict[str, set[str] | None]) -> None:
-    await _execute_retrieval_benchmark(item, trace, "docx", valid_docs_per_parser)
-
-
-async def process_retrieval_txt(item: Any, trace: Any, valid_docs_per_parser: dict[str, set[str] | None]) -> None:
-    await _execute_retrieval_benchmark(item, trace, "txt", valid_docs_per_parser)
-
-
-async def run_retrieval_benchmarks(limit: int, workers: int, docs_dict: dict[str, Any]) -> None:
+async def run_retrieval_benchmarks(limit: int, workers: int, docs_dict: Dict[str, Any]) -> None:
     valid_docs_per_parser = {
         parser: _get_valid_document_ids_for_parser(parser)
         for parser in PARSERS
     }
 
-    await run_dataset_benchmark(
-        dataset_name="character_states",
-        run_name="benchmark_retrieval_docling",
-        process_fn=functools.partial(process_retrieval_docling, valid_docs_per_parser=valid_docs_per_parser),
-        limit=limit,
-        workers=workers
-    )
-
-    await run_dataset_benchmark(
-        dataset_name="character_states",
-        run_name="benchmark_retrieval_pymupdf",
-        process_fn=functools.partial(process_retrieval_pymupdf, valid_docs_per_parser=valid_docs_per_parser),
-        limit=limit,
-        workers=workers
-    )
-
-    await run_dataset_benchmark(
-        dataset_name="character_states",
-        run_name="benchmark_retrieval_docx",
-        process_fn=functools.partial(process_retrieval_docx, valid_docs_per_parser=valid_docs_per_parser),
-        limit=limit,
-        workers=workers
-    )
-
-    await run_dataset_benchmark(
-        dataset_name="character_states",
-        run_name="benchmark_retrieval_txt",
-        process_fn=functools.partial(process_retrieval_txt, valid_docs_per_parser=valid_docs_per_parser),
-        limit=limit,
-        workers=workers
-    )
+    for parser_name in PARSERS:
+        await run_dataset_benchmark(
+            dataset_name="character_states",
+            run_name=f"benchmark_retrieval_{parser_name}",
+            task_fn=functools.partial(retrieval_task, parser_name=parser_name),
+            filter_fn=lambda item, p=parser_name: filter_retrieval_items(item, p, valid_docs_per_parser),
+            limit=limit,
+            workers=workers
+        )

--- a/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/services.py
+++ b/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/services.py
@@ -11,18 +11,22 @@ logger = structlog.get_logger(__name__)
 async def run_dataset_benchmark(
     dataset_name: str,
     run_name: str,
-    process_fn: Callable[[Any, Any], Any],
+    task_fn: Callable[..., Any],
     limit: int,
     workers: int,
+    evaluators: list[Any] | None = None,
+    filter_fn: Callable[[Any], bool] | None = None,
 ) -> None:
-    """Executes a benchmark over a Langfuse dataset.
+    """Executes a benchmark over a Langfuse dataset using Langfuse Experiments API.
 
     Args:
         dataset_name (str): The name of the Langfuse dataset to run against.
-        run_name (str): The name for this benchmark run/trace.
-        process_fn (Callable): The async function to execute for each item. Must take (item, trace).
+        run_name (str): The name for this benchmark run/experiment.
+        task_fn (Callable): The function conforming to TaskFunction protocol to execute for each item.
         limit (int): Maximum number of unique documents to process.
         workers (int): Number of concurrent tasks.
+        evaluators (list, optional): Optional list of client-side evaluators.
+        filter_fn (Callable, optional): Optional function to pre-filter items.
     """
     logger.info("Starting benchmark run", run_name=run_name, dataset_name=dataset_name)
     lanfuse_client = langfuse.Langfuse()
@@ -40,10 +44,13 @@ async def run_dataset_benchmark(
         logger.warning("Dataset has 0 items!", dataset_name=dataset_name)
         return
 
-    # Filter dataset.items based on limit (applying limit uniquely by document_id).
+    # Filter dataset.items based on filter_fn and limit (applying limit uniquely by document_id).
     filtered_items = []
     seen_docs = set()
     for item in items:
+        if filter_fn and not filter_fn(item):
+            continue
+
         doc_id = None
         if isinstance(item.input, dict):
             doc_id = item.input.get("document_id")
@@ -73,78 +80,20 @@ async def run_dataset_benchmark(
         total_items=len(items),
     )
 
-    semaphore = asyncio.Semaphore(workers)
+    if not filtered_items:
+        logger.warning("No items left after filtering!", dataset_name=dataset_name)
+        return
 
-    async def _run(item: Any, index: int) -> None:
-        async with semaphore:
-            doc_id = None
-            if isinstance(item.input, dict):
-                doc_id = item.input.get("document_id")
-            elif hasattr(item.input, "document_id"):
-                doc_id = getattr(item.input, "document_id")
-            elif isinstance(item.input, str):
-                import json
-                try:
-                    parsed = json.loads(item.input)
-                    if isinstance(parsed, dict):
-                        doc_id = parsed.get("document_id")
-                except Exception:
-                    pass
-
-            item_id = getattr(item, "id", "unknown")
-            logger.info("Processing benchmark item", item_index=index + 1, total_items=len(filtered_items), document_id=doc_id, item_id=item_id)
-            
-            context_manager = lanfuse_client.start_as_current_observation(
-                name=run_name, as_type="span", input=item.input
-            )
-            
-            if not context_manager:
-                return
-
-            with context_manager as trace:
-                try:
-                    await process_fn(item, trace)
-                    
-                    await asyncio.to_thread(
-                        lanfuse_client.api.dataset_run_items.create,
-                        run_name=run_name,
-                        dataset_item_id=item.id,
-                        trace_id=trace.trace_id,
-                        observation_id=trace.id,
-                    )
-                except SkipBenchmark:
-                    pass
-                except FailBenchmark as e:
-                    logger.error(
-                        "Benchmark failed for item",
-                        item_id=item_id,
-                        document_id=doc_id,
-                        error=str(e),
-                    )
-                    error_msg = f"Error: {str(e)}"
-                    trace.update(level="ERROR", status_message=str(e), output=error_msg)
-                    await asyncio.to_thread(
-                        lanfuse_client.api.dataset_run_items.create,
-                        run_name=run_name,
-                        dataset_item_id=item.id,
-                        trace_id=trace.trace_id,
-                        observation_id=trace.id,
-                    )
-                except Exception as e:
-                    logger.exception(
-                        "Unexpected error for item",
-                        item_id=item_id,
-                        document_id=doc_id,
-                    )
-                    error_msg = f"Error: {str(e)}"
-                    trace.update(level="ERROR", status_message=str(e), output=error_msg)
-                    await asyncio.to_thread(
-                        lanfuse_client.api.dataset_run_items.create,
-                        run_name=run_name,
-                        dataset_item_id=item.id,
-                        trace_id=trace.trace_id,
-                        observation_id=trace.id,
-                    )
-
-    await asyncio.gather(*[_run(item, index) for index, item in enumerate(filtered_items)])
+    try:
+        await asyncio.to_thread(
+            lanfuse_client.run_experiment,
+            name=run_name,
+            data=filtered_items,
+            task=task_fn,
+            evaluators=evaluators or [],
+            max_concurrency=workers,
+        )
+    except Exception as e:
+        logger.exception("Failed to run experiment", run_name=run_name, exc_info=e)
+        
     logger.info("Finished benchmark run", run_name=run_name)

--- a/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/tools.py
+++ b/apps/matrixcurator-benchmark/src/matrixcurator_benchmark/tools.py
@@ -4,19 +4,45 @@ from typing import Any, Dict
 import structlog
 import functools
 
-from matrixcurator_benchmark.exceptions import FailBenchmark, SkipBenchmark
 from matrixcurator_benchmark.services import run_dataset_benchmark
 
 logger = structlog.get_logger(__name__)
 
-async def _execute_tool_benchmark(
-    item: Any,
-    trace: Any,
-    tool_name: str,
-    requires_pages: bool,
+
+def filter_tool_items(item: Any, expected_mime: str, docs_dict: Dict[str, Any]) -> bool:
+    input_data = item.input
+    
+    document_id = None
+    if isinstance(input_data, dict):
+        document_id = input_data.get("document_id")
+    elif hasattr(input_data, "document_id"):
+        document_id = getattr(input_data, "document_id", None)
+    elif isinstance(input_data, str):
+        try:
+            parsed = json.loads(input_data)
+            if isinstance(parsed, dict):
+                document_id = parsed.get("document_id")
+        except Exception:
+            pass
+
+    doc_row = docs_dict.get(document_id)
+    if not doc_row:
+        return False
+        
+    if doc_row.get("mime_type", "") != expected_mime:
+        return False
+        
+    return True
+
+
+async def tool_task(
+    *, 
+    item: Any, 
+    tool_name: str, 
+    requires_pages: bool, 
     docs_dict: Dict[str, Any],
-    expected_mime: str,
-) -> None:
+    **kwargs
+) -> str:
     input_data = item.input
     
     document_id = None
@@ -38,10 +64,7 @@ async def _execute_tool_benchmark(
 
     doc_row = docs_dict.get(document_id)
     if not doc_row:
-        raise SkipBenchmark(f"Document {document_id} not found in parquet data.")
-        
-    if doc_row.get("mime_type", "") != expected_mime:
-        raise SkipBenchmark(f"Skipping {document_id} because mime_type != {expected_mime}")
+        raise ValueError(f"Document {document_id} not found in parquet data.")
         
     if pages is None or (hasattr(pages, "__len__") and len(pages) == 0):
         # Resolve all available pages from the parsed text
@@ -89,7 +112,7 @@ async def _execute_tool_benchmark(
         is_missing = True
 
     if is_missing:
-        raise FailBenchmark(f"{tool_name} parsing failed: missing text in parquet cache for doc {document_id}")
+        raise ValueError(f"{tool_name} parsing failed: missing text in parquet cache for doc {document_id}")
 
     try:
         if isinstance(pre_parsed_text, str):
@@ -97,7 +120,7 @@ async def _execute_tool_benchmark(
         elif isinstance(pre_parsed_text, (list, tuple)):
             parses = list(pre_parsed_text)
         else:
-            raise FailBenchmark(f"{tool_name} parsing failed: Unsupported type {type(pre_parsed_text)} for parsed text")
+            raise ValueError(f"{tool_name} parsing failed: Unsupported type {type(pre_parsed_text)} for parsed text")
             
         if not isinstance(parses, list):
             if parses is None:
@@ -124,80 +147,31 @@ async def _execute_tool_benchmark(
                             break
 
                     if not missing_pages and content_list:
-                        result = "\n\n".join(content_list)
-                        trace.update(output=result)
-                        return
+                        return "\n\n".join(content_list)
                 else:
                     sorted_pages = sorted(
                         [pg for pg in parsed_pages if isinstance(pg, dict)], key=lambda x: x.get("page", 0)
                     )
                     content_list = [pg.get("content", "") for pg in sorted_pages]
                     if content_list:
-                        result = "\n\n".join(content_list)
-                        trace.update(output=result)
-                        return
+                        return "\n\n".join(content_list)
                         
-        raise FailBenchmark(f"{tool_name} parsing failed: Could not find valid parsed content for required pages.")
-    except SkipBenchmark:
-        raise
-    except FailBenchmark:
-        raise
+        raise ValueError(f"{tool_name} parsing failed: Could not find valid parsed content for required pages.")
     except Exception as e:
         logger.warning(
             "Failed to load pre-parsed text", document_id=document_id, error=str(e)
         )
-        raise FailBenchmark(f"{tool_name} parsing failed: {str(e)}")
-
-
-async def process_docling(item: Any, trace: Any, docs_dict: Dict[str, Any]) -> None:
-    await _execute_tool_benchmark(
-        item=item,
-        trace=trace,
-        tool_name="Docling",
-        requires_pages=True,
-        docs_dict=docs_dict,
-        expected_mime="application/pdf",
-    )
-
-
-async def process_pymupdf(item: Any, trace: Any, docs_dict: Dict[str, Any]) -> None:
-    await _execute_tool_benchmark(
-        item=item,
-        trace=trace,
-        tool_name="PyMuPDF",
-        requires_pages=True,
-        docs_dict=docs_dict,
-        expected_mime="application/pdf",
-    )
-
-
-async def process_docx(item: Any, trace: Any, docs_dict: Dict[str, Any]) -> None:
-    await _execute_tool_benchmark(
-        item=item,
-        trace=trace,
-        tool_name="DOCX",
-        requires_pages=False,
-        docs_dict=docs_dict,
-        expected_mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    )
-
-
-async def process_txt(item: Any, trace: Any, docs_dict: Dict[str, Any]) -> None:
-    await _execute_tool_benchmark(
-        item=item,
-        trace=trace,
-        tool_name="TXT",
-        requires_pages=False,
-        docs_dict=docs_dict,
-        expected_mime="text/plain",
-    )
+        raise ValueError(f"{tool_name} parsing failed: {str(e)}")
 
 
 async def run_tools_benchmarks(limit: int, workers: int, docs_dict: Dict[str, Any]) -> None:
     await run_dataset_benchmark(
         dataset_name="character_states",
         run_name="benchmark_tool_docling",
-        process_fn=functools.partial(process_docling, docs_dict=docs_dict),
+        task_fn=functools.partial(
+            tool_task, tool_name="Docling", requires_pages=True, docs_dict=docs_dict
+        ),
+        filter_fn=lambda item: filter_tool_items(item, "application/pdf", docs_dict),
         limit=limit,
         workers=workers
     )
@@ -205,7 +179,10 @@ async def run_tools_benchmarks(limit: int, workers: int, docs_dict: Dict[str, An
     await run_dataset_benchmark(
         dataset_name="character_states",
         run_name="benchmark_tool_pymupdf",
-        process_fn=functools.partial(process_pymupdf, docs_dict=docs_dict),
+        task_fn=functools.partial(
+            tool_task, tool_name="PyMuPDF", requires_pages=True, docs_dict=docs_dict
+        ),
+        filter_fn=lambda item: filter_tool_items(item, "application/pdf", docs_dict),
         limit=limit,
         workers=workers
     )
@@ -213,7 +190,12 @@ async def run_tools_benchmarks(limit: int, workers: int, docs_dict: Dict[str, An
     await run_dataset_benchmark(
         dataset_name="character_states",
         run_name="benchmark_tool_docx",
-        process_fn=functools.partial(process_docx, docs_dict=docs_dict),
+        task_fn=functools.partial(
+            tool_task, tool_name="DOCX", requires_pages=False, docs_dict=docs_dict
+        ),
+        filter_fn=lambda item: filter_tool_items(
+            item, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", docs_dict
+        ),
         limit=limit,
         workers=workers
     )
@@ -221,7 +203,10 @@ async def run_tools_benchmarks(limit: int, workers: int, docs_dict: Dict[str, An
     await run_dataset_benchmark(
         dataset_name="character_states",
         run_name="benchmark_tool_txt",
-        process_fn=functools.partial(process_txt, docs_dict=docs_dict),
+        task_fn=functools.partial(
+            tool_task, tool_name="TXT", requires_pages=False, docs_dict=docs_dict
+        ),
+        filter_fn=lambda item: filter_tool_items(item, "text/plain", docs_dict),
         limit=limit,
         workers=workers
     )

--- a/apps/matrixcurator-benchmark/tests/unit/matrixcurator_benchmark/test_services.py
+++ b/apps/matrixcurator-benchmark/tests/unit/matrixcurator_benchmark/test_services.py
@@ -1,12 +1,11 @@
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 from matrixcurator_benchmark.services import run_dataset_benchmark
-from matrixcurator_benchmark.exceptions import SkipBenchmark, FailBenchmark
-
 
 @pytest.mark.asyncio
 @patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_success(mock_langfuse_class):
+@patch("matrixcurator_benchmark.services.asyncio.to_thread")
+async def test_run_dataset_benchmark_success(mock_to_thread, mock_langfuse_class):
     mock_lf = MagicMock()
     mock_langfuse_class.return_value = mock_lf
     
@@ -15,37 +14,32 @@ async def test_run_dataset_benchmark_success(mock_langfuse_class):
     
     # Mock items
     item1 = MagicMock()
-    item1.id = "item1_id"
     item1.input = {"document_id": "doc1"}
     
     item2 = MagicMock()
-    item2.id = "item2_id"
     item2.input = {"document_id": "doc2"}
     
     mock_dataset.items = [item1, item2]
     
-    # Mock trace
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
+    mock_task_fn = MagicMock()
     
-    mock_process_fn = AsyncMock()
+    await run_dataset_benchmark("test_dataset", "test_run", mock_task_fn, limit=0, workers=2)
     
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=0, workers=2)
-    
-    # Check that process_fn was called for each item
-    assert mock_process_fn.call_count == 2
-    mock_process_fn.assert_any_call(item1, mock_trace)
-    mock_process_fn.assert_any_call(item2, mock_trace)
-    
-    # Check that link was called
-    assert mock_lf.api.dataset_run_items.create.call_count == 2
+    # Check that to_thread was called with run_experiment
+    mock_to_thread.assert_called_once()
+    args, kwargs = mock_to_thread.call_args
+    assert args[0] == mock_lf.run_experiment
+    assert kwargs["name"] == "test_run"
+    assert kwargs["data"] == [item1, item2]
+    assert kwargs["task"] == mock_task_fn
+    assert kwargs["evaluators"] == []
+    assert kwargs["max_concurrency"] == 2
 
 
 @pytest.mark.asyncio
 @patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_limit(mock_langfuse_class):
+@patch("matrixcurator_benchmark.services.asyncio.to_thread")
+async def test_run_dataset_benchmark_limit(mock_to_thread, mock_langfuse_class):
     mock_lf = MagicMock()
     mock_langfuse_class.return_value = mock_lf
     
@@ -53,119 +47,62 @@ async def test_run_dataset_benchmark_limit(mock_langfuse_class):
     mock_lf.get_dataset.return_value = mock_dataset
     
     item1 = MagicMock()
-    item1.id = "item1_id"
     item1.input = {"document_id": "doc1"}
     
     item2 = MagicMock()
-    item2.id = "item2_id"
     item2.input = {"document_id": "doc1"} # Same doc id
     
     item3 = MagicMock()
-    item3.id = "item3_id"
     item3.input = {"document_id": "doc2"}
     
     mock_dataset.items = [item1, item2, item3]
     
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
-    
-    mock_process_fn = AsyncMock()
+    mock_task_fn = MagicMock()
     
     # Limit to 1 document
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=1, workers=2)
+    await run_dataset_benchmark("test_dataset", "test_run", mock_task_fn, limit=1, workers=2)
     
-    # Should only process item1 and item2 because they are the first document
-    assert mock_process_fn.call_count == 2
-    
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert len(kwargs["data"]) == 2
+    assert kwargs["data"] == [item1, item2]
+
 
 @pytest.mark.asyncio
 @patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_skip(mock_langfuse_class):
+@patch("matrixcurator_benchmark.services.asyncio.to_thread")
+async def test_run_dataset_benchmark_filter(mock_to_thread, mock_langfuse_class):
     mock_lf = MagicMock()
     mock_langfuse_class.return_value = mock_lf
     mock_dataset = MagicMock()
     mock_lf.get_dataset.return_value = mock_dataset
     
     item1 = MagicMock()
-    item1.id = "item1_id"
     item1.input = {"document_id": "doc1"}
-    mock_dataset.items = [item1]
+    item2 = MagicMock()
+    item2.input = {"document_id": "doc2"}
     
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
+    mock_dataset.items = [item1, item2]
     
-    async def mock_process_fn(item, trace):
-        raise SkipBenchmark("skip")
+    mock_task_fn = MagicMock()
     
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=0, workers=2)
+    def mock_filter(item):
+        return item.input.get("document_id") == "doc2"
     
-    # Link should NOT be called
-    assert mock_lf.api.dataset_run_items.create.call_count == 0
+    await run_dataset_benchmark(
+        "test_dataset", "test_run", mock_task_fn, limit=0, workers=2, filter_fn=mock_filter
+    )
+    
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert len(kwargs["data"]) == 1
+    assert kwargs["data"] == [item2]
 
 
 @pytest.mark.asyncio
 @patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_fail(mock_langfuse_class):
-    mock_lf = MagicMock()
-    mock_langfuse_class.return_value = mock_lf
-    mock_dataset = MagicMock()
-    mock_lf.get_dataset.return_value = mock_dataset
-    
-    item1 = MagicMock()
-    item1.id = "item1_id"
-    item1.input = {"document_id": "doc1"}
-    mock_dataset.items = [item1]
-    
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
-    
-    async def mock_process_fn(item, trace):
-        raise FailBenchmark("fail")
-    
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=0, workers=2)
-    
-    # Trace should be updated with error AND output string for evaluators
-    mock_trace.update.assert_called_with(level="ERROR", status_message="fail", output="Error: fail")
-    
-    # Link SHOULD be called
-    assert mock_lf.api.dataset_run_items.create.call_count == 1
-
-
-
-@pytest.mark.asyncio
-@patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_unexpected_fail(mock_langfuse_class):
-    mock_lf = MagicMock()
-    mock_langfuse_class.return_value = mock_lf
-    mock_dataset = MagicMock()
-    mock_lf.get_dataset.return_value = mock_dataset
-    
-    item1 = MagicMock()
-    item1.id = "item1_id"
-    item1.input = {"document_id": "doc1"}
-    mock_dataset.items = [item1]
-    
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
-    
-    async def mock_process_fn(item, trace):
-        raise ValueError("unexpected")
-    
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=0, workers=2)
-    
-    # Trace should be updated with error AND output string for evaluators
-    mock_trace.update.assert_called_with(level="ERROR", status_message="unexpected", output="Error: unexpected")
-    
-    # Link SHOULD be called
-    assert mock_lf.api.dataset_run_items.create.call_count == 1
+@patch("matrixcurator_benchmark.services.asyncio.to_thread")
+async def test_run_dataset_benchmark_resilient_input_parsing(mock_to_thread, mock_langfuse_class):
     mock_lf = MagicMock()
     mock_langfuse_class.return_value = mock_lf
     mock_dataset = MagicMock()
@@ -173,66 +110,25 @@ async def test_run_dataset_benchmark_unexpected_fail(mock_langfuse_class):
     
     # 1. Dict input
     item1 = MagicMock()
-    item1.id = "item1_id"
     item1.input = {"document_id": "doc1"}
     
     # 2. Object input
     class ObjInput:
         document_id = "doc2"
     item2 = MagicMock()
-    item2.id = "item2_id"
     item2.input = ObjInput()
     
     # 3. JSON string input
     item3 = MagicMock()
-    item3.id = "item3_id"
     item3.input = '{"document_id": "doc3"}'
     
     mock_dataset.items = [item1, item2, item3]
     
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
+    mock_task_fn = MagicMock()
     
-    mock_process_fn = AsyncMock()
+    await run_dataset_benchmark("test_dataset", "test_run", mock_task_fn, limit=2, workers=1)
     
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=3, workers=1)
-    
-@pytest.mark.asyncio
-@patch("matrixcurator_benchmark.services.langfuse.Langfuse")
-async def test_run_dataset_benchmark_resilient_input_parsing(mock_langfuse_class):
-    mock_lf = MagicMock()
-    mock_langfuse_class.return_value = mock_lf
-    mock_dataset = MagicMock()
-    mock_lf.get_dataset.return_value = mock_dataset
-    
-    # 1. Dict input
-    item1 = MagicMock()
-    item1.id = "item1_id"
-    item1.input = {"document_id": "doc1"}
-    
-    # 2. Object input
-    class ObjInput:
-        document_id = "doc2"
-    item2 = MagicMock()
-    item2.id = "item2_id"
-    item2.input = ObjInput()
-    
-    # 3. JSON string input
-    item3 = MagicMock()
-    item3.id = "item3_id"
-    item3.input = '{"document_id": "doc3"}'
-    
-    mock_dataset.items = [item1, item2, item3]
-    
-    mock_trace = MagicMock()
-    mock_trace.id = "trace_id_123"
-    mock_trace.trace_id = "trace_id_123_456"
-    mock_lf.start_as_current_observation.return_value.__enter__.return_value = mock_trace
-    
-    mock_process_fn = AsyncMock()
-    
-    await run_dataset_benchmark("test_dataset", "test_run", mock_process_fn, limit=3, workers=1)
-    
-    assert mock_process_fn.call_count == 3
+    mock_to_thread.assert_called_once()
+    _, kwargs = mock_to_thread.call_args
+    assert len(kwargs["data"]) == 2
+    assert kwargs["data"] == [item1, item2]

--- a/apps/matrixcurator-benchmark/tests/unit/matrixcurator_benchmark/test_tools.py
+++ b/apps/matrixcurator-benchmark/tests/unit/matrixcurator_benchmark/test_tools.py
@@ -1,34 +1,23 @@
 import pytest
 import json
-from unittest.mock import MagicMock
-
-from matrixcurator_benchmark.tools import (
-    _execute_tool_benchmark,
-)
-from matrixcurator_benchmark.exceptions import SkipBenchmark, FailBenchmark
+from matrixcurator_benchmark.tools import tool_task, filter_tool_items
 
 class MockDatasetItem:
     def __init__(self, input_data):
         self.input = input_data
 
-@pytest.mark.asyncio
-async def test_execute_tool_benchmark_skip_wrong_mime():
+def test_filter_tool_items_skip_wrong_mime():
     dataset_item = MockDatasetItem({"document_id": "pdf_doc"})
     docs_dict = {"pdf_doc": {"mime_type": "text/plain"}}
-    trace = MagicMock()
+    assert not filter_tool_items(dataset_item, "application/pdf", docs_dict)
 
-    with pytest.raises(SkipBenchmark, match="Skipping pdf_doc because mime_type != application/pdf"):
-        await _execute_tool_benchmark(
-            item=dataset_item,
-            trace=trace,
-            tool_name="TestTool",
-            requires_pages=True,
-            docs_dict=docs_dict,
-            expected_mime="application/pdf",
-        )
+def test_filter_tool_items_doc_not_found():
+    dataset_item = MockDatasetItem({"document_id": "missing"})
+    docs_dict = {}
+    assert not filter_tool_items(dataset_item, "application/pdf", docs_dict)
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_success():
+async def test_tool_task_success():
     pre_parsed_data = [
         {
             "parser": "testtool",
@@ -41,39 +30,33 @@ async def test_execute_tool_benchmark_success():
     
     dataset_item = MockDatasetItem({"document_id": "doc2", "pages": [1, 2]})
     docs_dict = {"doc2": {"mime_type": "application/pdf", "text": json.dumps(pre_parsed_data)}}
-    trace = MagicMock()
 
-    await _execute_tool_benchmark(
+    result = await tool_task(
         item=dataset_item,
-        trace=trace,
         tool_name="TestTool",
         requires_pages=True,
         docs_dict=docs_dict,
-        expected_mime="application/pdf",
     )
 
-    trace.update.assert_called_once_with(output="Page 1 content\n\nPage 2 content")
+    assert result == "Page 1 content\n\nPage 2 content"
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_missing_text():
+async def test_tool_task_missing_text():
     dataset_item = MockDatasetItem({"document_id": "doc3", "pages": [3]})
     docs_dict = {"doc3": {"mime_type": "application/pdf", "text": None}}
-    trace = MagicMock()
 
-    with pytest.raises(FailBenchmark, match="TestTool parsing failed: missing text in parquet cache for doc doc3"):
-        await _execute_tool_benchmark(
+    with pytest.raises(ValueError, match="TestTool parsing failed: missing text in parquet cache for doc doc3"):
+        await tool_task(
             item=dataset_item,
-            trace=trace,
             tool_name="TestTool",
             requires_pages=True,
             docs_dict=docs_dict,
-            expected_mime="application/pdf",
         )
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_missing_page():
+async def test_tool_task_missing_page():
     pre_parsed_data = [
         {
             "parser": "testtool",
@@ -84,21 +67,18 @@ async def test_execute_tool_benchmark_missing_page():
     ]
     dataset_item = MockDatasetItem({"document_id": "doc3", "pages": [1, 3]})
     docs_dict = {"doc3": {"mime_type": "application/pdf", "text": json.dumps(pre_parsed_data)}}
-    trace = MagicMock()
 
-    with pytest.raises(FailBenchmark, match="TestTool parsing failed: Could not find valid parsed content for required pages."):
-        await _execute_tool_benchmark(
+    with pytest.raises(ValueError, match="TestTool parsing failed: Could not find valid parsed content for required pages."):
+        await tool_task(
             item=dataset_item,
-            trace=trace,
             tool_name="TestTool",
             requires_pages=True,
             docs_dict=docs_dict,
-            expected_mime="application/pdf",
         )
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_success_with_list():
+async def test_tool_task_success_with_list():
     pre_parsed_data = [
         {
             "parser": "testtool",
@@ -110,57 +90,48 @@ async def test_execute_tool_benchmark_success_with_list():
     
     dataset_item = MockDatasetItem({"document_id": "doc_list", "pages": [1]})
     docs_dict = {"doc_list": {"mime_type": "application/pdf", "text": pre_parsed_data}}
-    trace = MagicMock()
 
-    await _execute_tool_benchmark(
+    result = await tool_task(
         item=dataset_item,
-        trace=trace,
         tool_name="TestTool",
         requires_pages=True,
         docs_dict=docs_dict,
-        expected_mime="application/pdf",
     )
 
-    trace.update.assert_called_once_with(output="Page 1 list content")
+    assert result == "Page 1 list content"
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_missing_text_empty_list():
+async def test_tool_task_missing_text_empty_list():
     dataset_item = MockDatasetItem({"document_id": "doc_empty", "pages": [1]})
     docs_dict = {"doc_empty": {"mime_type": "application/pdf", "text": []}}
-    trace = MagicMock()
 
-    with pytest.raises(FailBenchmark, match="TestTool parsing failed: missing text in parquet cache for doc doc_empty"):
-        await _execute_tool_benchmark(
+    with pytest.raises(ValueError, match="TestTool parsing failed: missing text in parquet cache for doc doc_empty"):
+        await tool_task(
             item=dataset_item,
-            trace=trace,
             tool_name="TestTool",
             requires_pages=True,
             docs_dict=docs_dict,
-            expected_mime="application/pdf",
         )
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_nan_handling():
+async def test_tool_task_nan_handling():
     import numpy as np
     dataset_item = MockDatasetItem({"document_id": "doc_nan", "pages": [1]})
     docs_dict = {"doc_nan": {"mime_type": "application/pdf", "text": np.nan}}
-    trace = MagicMock()
 
-    with pytest.raises(FailBenchmark, match="TestTool parsing failed: missing text in parquet cache for doc doc_nan"):
-        await _execute_tool_benchmark(
+    with pytest.raises(ValueError, match="TestTool parsing failed: missing text in parquet cache for doc doc_nan"):
+        await tool_task(
             item=dataset_item,
-            trace=trace,
             tool_name="TestTool",
             requires_pages=True,
             docs_dict=docs_dict,
-            expected_mime="application/pdf",
         )
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_handles_numpy_pages():
+async def test_tool_task_handles_numpy_pages():
     import numpy as np
     pre_parsed_data = [
         {
@@ -174,38 +145,19 @@ async def test_execute_tool_benchmark_handles_numpy_pages():
     
     dataset_item = MockDatasetItem({"document_id": "doc_numpy", "pages": np.array([1, 2], dtype=np.int64)})
     docs_dict = {"doc_numpy": {"mime_type": "application/pdf", "text": pre_parsed_data}}
-    trace = MagicMock()
 
-    await _execute_tool_benchmark(
+    result = await tool_task(
         item=dataset_item,
-        trace=trace,
         tool_name="TestTool",
         requires_pages=True,
         docs_dict=docs_dict,
-        expected_mime="application/pdf",
     )
 
-    trace.update.assert_called_once_with(output="Page 1 numpy content\n\nPage 2 string content")
+    assert result == "Page 1 numpy content\n\nPage 2 string content"
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_doc_not_found():
-    dataset_item = MockDatasetItem({"document_id": "missing"})
-    docs_dict = {}
-    
-    with pytest.raises(SkipBenchmark, match="Document missing not found"):
-        await _execute_tool_benchmark(
-            item=dataset_item,
-            trace=MagicMock(),
-            tool_name="TestTool",
-            requires_pages=True,
-            docs_dict=docs_dict,
-            expected_mime="application/pdf",
-        )
-
-
-@pytest.mark.asyncio
-async def test_execute_tool_benchmark_resilient_input_parsing():
+async def test_tool_task_resilient_input_parsing():
     pre_parsed_data = [
         {
             "parser": "testtool",
@@ -234,20 +186,17 @@ async def test_execute_tool_benchmark_resilient_input_parsing():
     item3 = MockDatasetItem('{"document_id": "doc3", "pages": [1]}')
     
     for item in [item1, item2, item3]:
-        trace = MagicMock()
-        await _execute_tool_benchmark(
+        result = await tool_task(
             item=item,
-            trace=trace,
             tool_name="TestTool",
             requires_pages=True,
             docs_dict=docs_dict,
-            expected_mime="application/pdf",
         )
-        trace.update.assert_called_once_with(output="Page 1 content")
+        assert result == "Page 1 content"
 
 
 @pytest.mark.asyncio
-async def test_execute_tool_benchmark_null_pages():
+async def test_tool_task_null_pages():
     pre_parsed_data = [
         {
             "parser": "testtool",
@@ -261,16 +210,13 @@ async def test_execute_tool_benchmark_null_pages():
     # Send missing/null pages
     dataset_item = MockDatasetItem({"document_id": "doc_null", "pages": []})
     docs_dict = {"doc_null": {"mime_type": "application/pdf", "text": pre_parsed_data}}
-    trace = MagicMock()
 
-    await _execute_tool_benchmark(
+    result = await tool_task(
         item=dataset_item,
-        trace=trace,
         tool_name="TestTool",
         requires_pages=True,
         docs_dict=docs_dict,
-        expected_mime="application/pdf",
     )
     
     # Should resolve both pages
-    trace.update.assert_called_once_with(output="Page 1 content\n\nPage 2 content")
+    assert result == "Page 1 content\n\nPage 2 content"


### PR DESCRIPTION
## 📝 Description
This PR migrates the internal benchmarking infrastructure to the Langfuse Experiments API, replacing manual trace tracking with a standardized, robust task-based execution pattern.

- Refactored `run_dataset_benchmark` to utilize `lanfuse_client.run_experiment` with support for `task_fn` and `filter_fn`.
- Updated retrieval and tool benchmarks to integrate with the new task/filter interface.
- Implemented `run_agents_benchmarks` to support agent-based evaluation workflows.
- Removed deprecated `FailBenchmark` and `SkipBenchmark` exception types, opting for standard Python exceptions and native experiment filtering.
- Aligned existing unit tests with the updated experimental execution structure.

## 🧪 How Has This Been Tested?
- [ ] Added new unit/integration tests
- [ ] Verified existing tests pass
- [ ] Manual testing

> _Steps to reproduce/test:_ 

## 🏷️ Type of Change
- [x] **feat:** A new feature (MINOR version bump)
- [ ] **fix:** A bug fix (PATCH version bump)
- [x] **refactor:** A code change that neither fixes a bug nor adds a feature
- [ ] **perf:** A code change that improves performance
- [ ] **docs:** Documentation only changes
- [ ] **style:** Changes that do not affect the meaning of the code
- [ ] **test:** Adding missing tests or correcting existing tests
- [ ] **chore:** Changes to the build process, CI/CD, or auxiliary tools

## 💥 Breaking Changes
- [x] **No**
- [ ] **Yes** 

## ✅ Developer Checklist
- [x] My PR title strictly follows `<type>[optional scope]: <description>`.
- [x] This PR contains a **single responsibility**.
- [x] I have performed a self-review of my own code.
- [x] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] All markdown lists in this description strictly use `-` instead of `*`.