### PR TITLE
feat/matrixcurator/add-concurrency-and-litellm-support

### DIFF
--- a/packages/matrixcurator/src/matrixcurator/integrations/docling.py
+++ b/packages/matrixcurator/src/matrixcurator/integrations/docling.py
@@ -6,107 +6,135 @@ from io import BytesIO
 from typing import List
 
 
-from docling.models.inference_engines.vlm.api_openai_compatible_engine import ApiVlmEngine
+from docling.models.inference_engines.vlm.api_openai_compatible_engine import (
+    ApiVlmEngine,
+)
 from docling.models.inference_engines.vlm.base import VlmEngineInput, VlmEngineOutput
 from docling.models.stages.vlm_convert.vlm_convert_model import VlmConvertModel
 from docling.pipeline.vlm_pipeline import VlmPipeline, VlmPipelineOptions
 
-from matrixcurator.integrations.mcp import MCPSamplingError, mcp_session_var, sample_message
+from matrixcurator.integrations.mcp import (
+    MCPSamplingError,
+    mcp_session_var,
+    sample_message,
+)
+from matrixcurator.integrations.litellm import completion
+from matrixcurator.config.main import settings
 
 logger = logging.getLogger(__name__)
+
 
 class McpVlmEngine(ApiVlmEngine):
     """
     Custom VLM Engine for Docling that intercepts calls for MCP sampling.
-    Falls back to ApiVlmEngine if no MCP session is active or if sampling fails.
+    Falls back to litellm.completion (Gemini) if no MCP session is active or if sampling fails.
     """
-    
+
     def predict_batch(self, input_batch: List[VlmEngineInput]) -> List[VlmEngineOutput]:
         session = mcp_session_var.get()
-        if session is not None:
-            try:
-                outputs = []
-                for input_data in input_batch:
-                    # Format image and prompt for MCP
-                    img_io = BytesIO()
-                    image = input_data.image.copy().convert("RGBA")
-                    image.save(img_io, "PNG")
-                    image_base64 = base64.b64encode(img_io.getvalue()).decode("utf-8")
-                    
-                    messages = [
+        outputs = []
+
+        for input_data in input_batch:
+            # Format image and prompt for MCP/LiteLLM
+            img_io = BytesIO()
+            image = input_data.image.copy().convert("RGBA")
+            image.save(img_io, "PNG")
+            image_base64 = base64.b64encode(img_io.getvalue()).decode("utf-8")
+
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
                         {
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "image_url",
-                                    "image_url": {
-                                        "url": f"data:image/png;base64,{image_base64}"
-                                    }
-                                },
-                                {
-                                    "type": "text",
-                                    "text": input_data.prompt
-                                }
-                            ]
-                        }
-                    ]
-                    
-                    request_start_time = time.time()
-                    
-                    # Execute MCP sampling synchronously
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{image_base64}"
+                            },
+                        },
+                        {"type": "text", "text": input_data.prompt},
+                    ],
+                }
+            ]
+
+            request_start_time = time.time()
+            content = ""
+
+            if session is not None:
+                # Execute MCP sampling synchronously
+                try:
                     try:
                         loop = asyncio.get_running_loop()
                     except RuntimeError:
                         loop = asyncio.new_event_loop()
                         asyncio.set_event_loop(loop)
-                        
+
                     if loop.is_running():
-                        logger.warning("Cannot run sync MCP sampling inside an active event loop. Falling back to native Docling API.")
-                        return super().predict_batch(input_batch)
-                        
+                        logger.warning(
+                            "Cannot run sync MCP sampling inside an active event loop. Falling back to native LiteLLM."
+                        )
+                        raise RuntimeError("Event loop is already running")
+
                     mcp_result = loop.run_until_complete(
                         sample_message(
                             session=session,
                             messages=messages,
                             temperature=input_data.temperature,
-                            max_tokens=input_data.max_new_tokens
+                            max_tokens=input_data.max_new_tokens,
                         )
                     )
-                    
+
                     # Extract text content
-                    content = ""
                     if hasattr(mcp_result, "content"):
                         for item in mcp_result.content:
                             if getattr(item, "type", "") == "text":
                                 content += getattr(item, "text", "")
-                                
-                    generation_time = time.time() - request_start_time
-                    
-                    outputs.append(
-                        VlmEngineOutput(
-                            text=content,
-                            stop_reason="stop",
-                            metadata={
-                                "generation_time": generation_time,
-                                "num_tokens": 0,
-                            }
-                        )
+
+                except MCPSamplingError as e:
+                    logger.warning(
+                        f"MCP sampling failed, falling back to native LiteLLM: {e}"
                     )
-                    
-                return outputs
-                
-            except MCPSamplingError as e:
-                logger.warning(f"MCP sampling failed, falling back to native Docling API: {e}")
-            except Exception as e:
-                logger.warning(f"Unexpected error during MCP sampling, falling back to native Docling API: {e}")
-                
-        # Fallback to native Docling API
-        return super().predict_batch(input_batch)
+                    session = None  # Trigger fallback
+                except Exception as e:
+                    logger.warning(
+                        f"Unexpected error during MCP sampling, falling back to native LiteLLM: {e}"
+                    )
+                    session = None  # Trigger fallback
+
+            if session is None:
+                # Fallback to LiteLLM (Gemini)
+                try:
+                    response = completion(
+                        model=settings.vlm_model,
+                        messages=messages,
+                        temperature=input_data.temperature,
+                        max_tokens=input_data.max_new_tokens,
+                    )
+                    content = response.choices[0].message.content or ""
+                except Exception as e:
+                    logger.error(f"LiteLLM fallback failed: {e}")
+                    content = ""
+
+            generation_time = time.time() - request_start_time
+
+            outputs.append(
+                VlmEngineOutput(
+                    text=content,
+                    stop_reason="stop",
+                    metadata={
+                        "generation_time": generation_time,
+                        "num_tokens": 0,
+                    },
+                )
+            )
+
+        return outputs
+
 
 class McpVlmConvertModel(VlmConvertModel):
     """
     Custom VlmConvertModel that injects McpVlmEngine.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Replace the engine with our MCP-aware engine
@@ -114,16 +142,44 @@ class McpVlmConvertModel(VlmConvertModel):
         if hasattr(self, "options") and hasattr(self.options, "engine_options"):
             self.engine = McpVlmEngine(
                 enable_remote_services=getattr(self, "enable_remote_services", True),
-                options=self.options.engine_options
+                options=self.options.engine_options,
             )
+
 
 class McpVlmPipeline(VlmPipeline):
     """
     Custom VlmPipeline that uses McpVlmConvertModel.
     """
-    def _initialize_new_runtime_system(self, pipeline_options: VlmPipelineOptions) -> None:
+
+    def _initialize_new_runtime_system(
+        self, pipeline_options: VlmPipelineOptions
+    ) -> None:
+        try:
+            from docling.datamodel.vlm_engine_options import (
+                ApiVlmEngineOptions,
+                VlmEngineType,
+            )
+
+            if (
+                not getattr(pipeline_options.vlm_options, "engine_options", None)
+                or getattr(pipeline_options.vlm_options.engine_options, "engine_type", None)
+                != VlmEngineType.API_OLLAMA
+            ):
+                pipeline_options.vlm_options.engine_options = ApiVlmEngineOptions(
+                    engine_type=VlmEngineType.API_OLLAMA,
+                    url="http://localhost:11434/v1/chat/completions",
+                )
+        except ImportError:
+            from docling.datamodel.pipeline_options_vlm_model import ApiVlmOptions
+
+            if not isinstance(pipeline_options.vlm_options.engine_options, ApiVlmOptions):
+                pipeline_options.vlm_options.engine_options = ApiVlmOptions(
+                    prompt=getattr(pipeline_options.vlm_options, "model_spec", pipeline_options.vlm_options).prompt,
+                    response_format=getattr(pipeline_options.vlm_options, "model_spec", pipeline_options.vlm_options).response_format,
+                )
+
         super()._initialize_new_runtime_system(pipeline_options)
-        
+
         # Replace VlmConvertModel with McpVlmConvertModel in the build pipe
         for i, model in enumerate(self.build_pipe):
             if isinstance(model, VlmConvertModel):
@@ -135,4 +191,3 @@ class McpVlmPipeline(VlmPipeline):
                     accelerator_options=self.pipeline_options.accelerator_options,
                 )
                 logger.info("Injected McpVlmConvertModel into Docling pipeline")
-

--- a/packages/matrixcurator/src/matrixcurator/integrations/docling.py
+++ b/packages/matrixcurator/src/matrixcurator/integrations/docling.py
@@ -2,6 +2,8 @@ import asyncio
 import base64
 import logging
 import time
+import concurrent.futures
+import contextvars
 from io import BytesIO
 from typing import List
 
@@ -24,6 +26,84 @@ from matrixcurator.config.main import settings
 logger = logging.getLogger(__name__)
 
 
+def _process_single_input(input_data: VlmEngineInput) -> VlmEngineOutput:
+    session = mcp_session_var.get()
+
+    # Format image and prompt for MCP/LiteLLM
+    img_io = BytesIO()
+    image = input_data.image.copy().convert("RGBA")
+    image.save(img_io, "PNG")
+    image_base64 = base64.b64encode(img_io.getvalue()).decode("utf-8")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image_base64}"
+                    },
+                },
+                {"type": "text", "text": input_data.prompt},
+            ],
+        }
+    ]
+
+    request_start_time = time.time()
+    content = ""
+
+    if session is not None:
+        # Execute MCP sampling synchronously
+        try:
+            mcp_result = asyncio.run(
+                sample_message(
+                    session=session,
+                    messages=messages,
+                    temperature=input_data.temperature,
+                    max_tokens=input_data.max_new_tokens,
+                )
+            )
+
+            # Extract text content
+            if hasattr(mcp_result, "content"):
+                for item in mcp_result.content:
+                    if getattr(item, "type", "") == "text":
+                        content += getattr(item, "text", "")
+
+        except MCPSamplingError as e:
+            logger.warning(
+                f"MCP sampling failed, falling back to native LiteLLM: {e}"
+            )
+            session = None  # Trigger fallback
+        except Exception as e:
+            logger.warning(
+                f"Unexpected error during MCP sampling, falling back to native LiteLLM: {e}"
+            )
+            session = None  # Trigger fallback
+
+    if session is None:
+        # Fallback to LiteLLM (Gemini)
+        response = completion(
+            model=settings.vlm_model,
+            messages=messages,
+            temperature=input_data.temperature,
+            max_tokens=input_data.max_new_tokens,
+        )
+        content = response.choices[0].message.content or ""
+
+    generation_time = time.time() - request_start_time
+
+    return VlmEngineOutput(
+        text=content,
+        stop_reason="stop",
+        metadata={
+            "generation_time": generation_time,
+            "num_tokens": 0,
+        },
+    )
+
+
 class McpVlmEngine(ApiVlmEngine):
     """
     Custom VLM Engine for Docling that intercepts calls for MCP sampling.
@@ -31,101 +111,21 @@ class McpVlmEngine(ApiVlmEngine):
     """
 
     def predict_batch(self, input_batch: List[VlmEngineInput]) -> List[VlmEngineOutput]:
-        session = mcp_session_var.get()
         outputs = []
 
-        for input_data in input_batch:
-            # Format image and prompt for MCP/LiteLLM
-            img_io = BytesIO()
-            image = input_data.image.copy().convert("RGBA")
-            image.save(img_io, "PNG")
-            image_base64 = base64.b64encode(img_io.getvalue()).decode("utf-8")
+        # Let's use threads to run multiple VLM inputs concurrently.
+        # This matches upstream ApiVlmEngine pattern for API requests.
+        num_threads = min(len(input_batch) or 1, 8)  # max workers
 
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": f"data:image/png;base64,{image_base64}"
-                            },
-                        },
-                        {"type": "text", "text": input_data.prompt},
-                    ],
-                }
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+            # context.run propagates the contextvars to the thread.
+            futures = [
+                executor.submit(contextvars.copy_context().run, _process_single_input, input_data)
+                for input_data in input_batch
             ]
-
-            request_start_time = time.time()
-            content = ""
-
-            if session is not None:
-                # Execute MCP sampling synchronously
-                try:
-                    try:
-                        loop = asyncio.get_running_loop()
-                    except RuntimeError:
-                        loop = asyncio.new_event_loop()
-                        asyncio.set_event_loop(loop)
-
-                    if loop.is_running():
-                        logger.warning(
-                            "Cannot run sync MCP sampling inside an active event loop. Falling back to native LiteLLM."
-                        )
-                        raise RuntimeError("Event loop is already running")
-
-                    mcp_result = loop.run_until_complete(
-                        sample_message(
-                            session=session,
-                            messages=messages,
-                            temperature=input_data.temperature,
-                            max_tokens=input_data.max_new_tokens,
-                        )
-                    )
-
-                    # Extract text content
-                    if hasattr(mcp_result, "content"):
-                        for item in mcp_result.content:
-                            if getattr(item, "type", "") == "text":
-                                content += getattr(item, "text", "")
-
-                except MCPSamplingError as e:
-                    logger.warning(
-                        f"MCP sampling failed, falling back to native LiteLLM: {e}"
-                    )
-                    session = None  # Trigger fallback
-                except Exception as e:
-                    logger.warning(
-                        f"Unexpected error during MCP sampling, falling back to native LiteLLM: {e}"
-                    )
-                    session = None  # Trigger fallback
-
-            if session is None:
-                # Fallback to LiteLLM (Gemini)
-                try:
-                    response = completion(
-                        model=settings.vlm_model,
-                        messages=messages,
-                        temperature=input_data.temperature,
-                        max_tokens=input_data.max_new_tokens,
-                    )
-                    content = response.choices[0].message.content or ""
-                except Exception as e:
-                    logger.error(f"LiteLLM fallback failed: {e}")
-                    content = ""
-
-            generation_time = time.time() - request_start_time
-
-            outputs.append(
-                VlmEngineOutput(
-                    text=content,
-                    stop_reason="stop",
-                    metadata={
-                        "generation_time": generation_time,
-                        "num_tokens": 0,
-                    },
-                )
-            )
+            
+            for future in futures:
+                outputs.append(future.result())
 
         return outputs
 
@@ -170,13 +170,24 @@ class McpVlmPipeline(VlmPipeline):
                     url="http://localhost:11434/v1/chat/completions",
                 )
         except ImportError:
-            from docling.datamodel.pipeline_options_vlm_model import ApiVlmOptions
+            from docling.datamodel.pipeline_options_vlm_model import ApiVlmOptions, ResponseFormat
 
             if not isinstance(pipeline_options.vlm_options.engine_options, ApiVlmOptions):
                 pipeline_options.vlm_options.engine_options = ApiVlmOptions(
                     prompt=getattr(pipeline_options.vlm_options, "model_spec", pipeline_options.vlm_options).prompt,
-                    response_format=getattr(pipeline_options.vlm_options, "model_spec", pipeline_options.vlm_options).response_format,
+                    response_format=ResponseFormat.MARKDOWN,
                 )
+                
+        # Force response format to MARKDOWN to ensure Gemini's plain markdown output is correctly parsed 
+        # instead of failing silently when parsed as DOCTAGS.
+        try:
+            from docling.datamodel.pipeline_options_vlm_model import ResponseFormat
+            if hasattr(pipeline_options.vlm_options, "model_spec"):
+                pipeline_options.vlm_options.model_spec.response_format = ResponseFormat.MARKDOWN
+            else:
+                pipeline_options.vlm_options.response_format = ResponseFormat.MARKDOWN
+        except Exception:
+            pass
 
         super()._initialize_new_runtime_system(pipeline_options)
 

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/__init__.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/__init__.py
@@ -4,12 +4,31 @@ from matrixcurator.modules.tools import pymupdf
 from matrixcurator.modules.tools import re
 from matrixcurator.modules.tools import txt
 
-from matrixcurator.modules.tools.docling import (parse_with_docling,)
-from matrixcurator.modules.tools.docx import (parse_with_docx,)
-from matrixcurator.modules.tools.pymupdf import (parse_with_pymupdf,)
-from matrixcurator.modules.tools.re import (generate_with_re,)
-from matrixcurator.modules.tools.txt import (parse_with_txt,)
+from matrixcurator.modules.tools.docling import (
+    parse_with_docling,
+)
+from matrixcurator.modules.tools.docx import (
+    parse_with_docx,
+)
+from matrixcurator.modules.tools.pymupdf import (
+    parse_with_pymupdf,
+)
+from matrixcurator.modules.tools.re import (
+    generate_with_re,
+)
+from matrixcurator.modules.tools.txt import (
+    parse_with_txt,
+)
 
-__all__ = ['docling', 'docx', 'generate_with_re', 'parse_with_docling',
-           'parse_with_docx', 'parse_with_pymupdf', 'parse_with_txt',
-           'pymupdf', 're', 'txt']
+__all__ = [
+    "docling",
+    "docx",
+    "generate_with_re",
+    "parse_with_docling",
+    "parse_with_docx",
+    "parse_with_pymupdf",
+    "parse_with_txt",
+    "pymupdf",
+    "re",
+    "txt",
+]

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/docling.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/docling.py
@@ -1,17 +1,75 @@
 import io
+import asyncio
+import atexit
 from langchain_core.tools import tool
-from docling.document_converter import DocumentConverter
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.document import InputFormat
 from docling.datamodel.base_models import DocumentStream
+from docling.pipeline.vlm_pipeline import VlmPipelineOptions
+from matrixcurator.integrations.docling import McpVlmPipeline
 from matrixcurator.exceptions import DocumentParseError
+from typing import Optional
+from matrixcurator.utils.concurrency import AsyncRateLimiter, AsyncConcurrencyManager
+from matrixcurator.config.main import settings
+
+_manager = None
+_converter = None
+
+def get_manager() -> AsyncConcurrencyManager:
+    global _manager
+    if _manager is None:
+        limiter = AsyncRateLimiter(settings=settings.docling_rate_limit)
+        _manager = AsyncConcurrencyManager(rate_limiter=limiter)
+    return _manager
+
+def get_converter() -> DocumentConverter:
+    global _converter
+    if _converter is None:
+        pipeline_options = VlmPipelineOptions()
+        pipeline_options.enable_remote_services = True
+
+        _converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(
+                    pipeline_cls=McpVlmPipeline, pipeline_options=pipeline_options
+                )
+            }
+        )
+    return _converter
+
 
 @tool
-def parse_with_docling(file_content: bytes, filename: str) -> str:
+async def parse_with_docling(
+    file_content: bytes, filename: str, pages: list[int] | None = None
+) -> str:
     """Use this tool to parse complex documents (PDF, DOCX, HTML, etc.) using Docling. It is slower but highly accurate for complex layouts, tables, and reading order."""
-    try:
-        buf = io.BytesIO(file_content)
-        stream = DocumentStream(name=filename, stream=buf)
-        converter = DocumentConverter()
-        result = converter.convert(stream)
-        return result.document.export_to_markdown()
-    except Exception as e:
-        raise DocumentParseError(f"Failed to parse document with Docling: {str(e)}") from e
+    async with get_manager():
+        def _parse():
+            try:
+                buf = io.BytesIO(file_content)
+                stream = DocumentStream(name=filename, stream=buf)
+                
+                converter = get_converter()
+                
+                convert_kwargs = {}
+                if pages:
+                    convert_kwargs["page_range"] = (min(pages), max(pages))
+                    
+                result = converter.convert(stream, **convert_kwargs)
+                return result.document.export_to_markdown()
+            except Exception as e:
+                raise DocumentParseError(
+                    f"Failed to parse document with Docling: {str(e)}"
+                ) from e
+
+        return await asyncio.to_thread(_parse)
+
+
+def _cleanup_converter():
+    """Destroy the DocumentConverter singleton before Python starts tearing down modules."""
+    global _converter
+    if _converter is not None:
+        _converter = None
+
+
+atexit.register(_cleanup_converter)

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/docx.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/docx.py
@@ -1,18 +1,35 @@
 import io
+import asyncio
 from langchain_core.tools import tool
 from matrixcurator.exceptions import DocumentParseError
+from matrixcurator.utils.concurrency import AsyncRateLimiter, AsyncConcurrencyManager
+from matrixcurator.config.main import settings
 
 # Absolute import to avoid circular dependency with the file name
 import docx as python_docx
 
+_manager = None
+
+def get_manager() -> AsyncConcurrencyManager:
+    global _manager
+    if _manager is None:
+        limiter = AsyncRateLimiter(settings=settings.docx_rate_limit)
+        _manager = AsyncConcurrencyManager(rate_limiter=limiter)
+    return _manager
+
+
 @tool
-def parse_with_docx(file_content: bytes, filename: str) -> str:
+async def parse_with_docx(file_content: bytes, filename: str) -> str:
     """Use this tool to parse DOCX (Microsoft Word) files."""
-    try:
-        doc = python_docx.Document(io.BytesIO(file_content))
-        text = []
-        for para in doc.paragraphs:
-            text.append(para.text)
-        return "\n".join(text)
-    except Exception as e:
-        raise DocumentParseError(f"Failed to parse DOCX: {str(e)}") from e
+    async with get_manager():
+        def _parse():
+            try:
+                doc = python_docx.Document(io.BytesIO(file_content))
+                text = []
+                for para in doc.paragraphs:
+                    text.append(para.text)
+                return "\n".join(text)
+            except Exception as e:
+                raise DocumentParseError(f"Failed to parse DOCX: {str(e)}") from e
+
+        return await asyncio.to_thread(_parse)

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/pymupdf.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/pymupdf.py
@@ -1,15 +1,41 @@
 import fitz  # PyMuPDF
+import asyncio
 from langchain_core.tools import tool
 from matrixcurator.exceptions import DocumentParseError
+from matrixcurator.utils.concurrency import AsyncRateLimiter, AsyncConcurrencyManager
+from matrixcurator.config.main import settings
+
+_manager = None
+
+def get_manager() -> AsyncConcurrencyManager:
+    global _manager
+    if _manager is None:
+        limiter = AsyncRateLimiter(settings=settings.pymupdf_rate_limit)
+        _manager = AsyncConcurrencyManager(rate_limiter=limiter)
+    return _manager
+
 
 @tool
-def parse_with_pymupdf(file_content: bytes, filename: str) -> str:
+async def parse_with_pymupdf(
+    file_content: bytes, filename: str, pages: list[int] | None = None
+) -> str:
     """Use this tool to parse PDF files using PyMuPDF. It is fast and works well for standard text-heavy PDFs."""
-    try:
-        doc = fitz.open(stream=file_content, filetype="pdf")
-        text = ""
-        for page in doc:
-            text += page.get_text()
-        return text
-    except Exception as e:
-        raise DocumentParseError(f"Failed to parse PDF with PyMuPDF: {str(e)}") from e
+    async with get_manager():
+
+        def _parse():
+            try:
+                doc = fitz.open(stream=file_content, filetype="pdf")
+                text = ""
+                
+                if pages is not None:
+                    for p in pages:
+                        if 1 <= p <= len(doc):
+                            text += doc[p - 1].get_text()
+                else:
+                    for page in doc:
+                        text += page.get_text()
+                return text
+            except Exception as e:
+                raise DocumentParseError(f"Failed to parse PDF with PyMuPDF: {str(e)}") from e
+
+        return await asyncio.to_thread(_parse)

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/re.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/re.py
@@ -5,8 +5,11 @@ from matrixcurator.exceptions import NexusFormatError
 # Absolute import to avoid circular dependency with the file name
 import re as python_re
 
+
 @tool
-def generate_with_re(original_nexus: str, extracted_states: List[Dict[str, Any]]) -> bytes:
+def generate_with_re(
+    original_nexus: str, extracted_states: List[Dict[str, Any]]
+) -> bytes:
     """Use this tool to generate an updated NEXUS file by inserting the extracted character states."""
     if not original_nexus:
         raise NexusFormatError("Original NEXUS content is missing.")
@@ -20,7 +23,7 @@ def generate_with_re(original_nexus: str, extracted_states: List[Dict[str, Any]]
         char_idx = state.get("character_index")
         char_name = state.get("character_name", "").replace("'", "''")
         states_dict = state.get("states", {})
-        
+
         states_str = ""
         if states_dict:
             states_list = []
@@ -28,9 +31,9 @@ def generate_with_re(original_nexus: str, extracted_states: List[Dict[str, Any]]
                 v_clean = str(v).replace("'", "''")
                 states_list.append(f"{k} '{v_clean}'")
             states_str = ", ".join(states_list)
-        
+
         charstatelabels += f"\t{char_idx} '{char_name}' / {states_str},\n"
-    
+
     # Remove trailing comma and add semicolon
     if charstatelabels.endswith(",\n"):
         charstatelabels = charstatelabels[:-2] + "\n;\n"
@@ -39,12 +42,17 @@ def generate_with_re(original_nexus: str, extracted_states: List[Dict[str, Any]]
 
     # Insert before MATRIX
     # Find MATRIX case-insensitively
-    matrix_match = python_re.search(r'\bMATRIX\b', original_nexus, python_re.IGNORECASE)
+    matrix_match = python_re.search(r"\bMATRIX\b", original_nexus, python_re.IGNORECASE)
     if not matrix_match:
         raise NexusFormatError("MATRIX block not found in NEXUS file.")
-    
+
     insert_pos = matrix_match.start()
-    
-    updated_nexus = original_nexus[:insert_pos] + charstatelabels + "\n" + original_nexus[insert_pos:]
-    
+
+    updated_nexus = (
+        original_nexus[:insert_pos]
+        + charstatelabels
+        + "\n"
+        + original_nexus[insert_pos:]
+    )
+
     return updated_nexus.encode("utf-8")

--- a/packages/matrixcurator/src/matrixcurator/modules/tools/txt.py
+++ b/packages/matrixcurator/src/matrixcurator/modules/tools/txt.py
@@ -1,15 +1,33 @@
+import asyncio
 from langchain_core.tools import tool
 from matrixcurator.exceptions import DocumentParseError
+from matrixcurator.utils.concurrency import AsyncRateLimiter, AsyncConcurrencyManager
+from matrixcurator.config.main import settings
+
+_manager = None
+
+def get_manager() -> AsyncConcurrencyManager:
+    global _manager
+    if _manager is None:
+        limiter = AsyncRateLimiter(settings=settings.txt_rate_limit)
+        _manager = AsyncConcurrencyManager(rate_limiter=limiter)
+    return _manager
+
 
 @tool
-def parse_with_txt(file_content: bytes, filename: str) -> str:
+async def parse_with_txt(file_content: bytes, filename: str) -> str:
     """Use this tool to parse plain text (TXT) files."""
-    try:
-        return file_content.decode("utf-8")
-    except UnicodeDecodeError:
-        try:
-            return file_content.decode("latin-1")
-        except Exception as e:
-            raise DocumentParseError(f"Failed to parse TXT: {str(e)}") from e
-    except Exception as e:
-        raise DocumentParseError(f"Failed to parse TXT: {str(e)}") from e
+    async with get_manager():
+
+        def _parse():
+            try:
+                return file_content.decode("utf-8")
+            except UnicodeDecodeError:
+                try:
+                    return file_content.decode("latin-1")
+                except Exception as e:
+                    raise DocumentParseError(f"Failed to parse TXT: {str(e)}") from e
+            except Exception as e:
+                raise DocumentParseError(f"Failed to parse TXT: {str(e)}") from e
+
+        return await asyncio.to_thread(_parse)


### PR DESCRIPTION
## 📝 Description

This PR introduces performance and integration improvements for the MatrixCurator engine, focusing on concurrent processing and enhanced model support.

**What changed:**
- **Concurrency:** Integrated `ThreadPoolExecutor` for parallel document parsing and VLM input processing, utilizing `contextvars` to maintain MCP session state across threads.
- **LiteLLM Integration:** Replaced the generic Docling API fallback with LiteLLM, enabling native support for Gemini models.
- **Resource Management:** Converted synchronous parsing tools to asynchronous operations with rate limiting and added page range support for PyMuPDF and Docling tools.
- **Reliability:** Forced `MARKDOWN` response format in engine options to prevent parsing failures during model fallbacks.

**Why:**
- To significantly improve throughput and resource utilization when processing multiple documents or VLM inputs, while expanding model compatibility.

## 🧪 How Has This Been Tested?
- [ ] Added new unit/integration tests
- [ ] Verified existing tests pass
- [ ] Manual testing

## 🏷️ Type of Change
- [x] **feat:** A new feature (MINOR version bump)
- [ ] **fix:** A bug fix (PATCH version bump)
- [ ] **refactor:** A code change that neither fixes a bug nor adds a feature
- [ ] **perf:** A code change that improves performance
- [ ] **docs:** Documentation only changes
- [ ] **style:** Changes that do not affect the meaning of the code
- [ ] **test:** Adding missing tests or correcting existing tests
- [ ] **chore:** Changes to the build process, CI/CD, or auxiliary tools

## 💥 Breaking Changes
- [x] **No**
- [ ] **Yes**

## ✅ Developer Checklist
- [x] My PR title strictly follows `<type>[optional scope]: <description>`.
- [x] This PR contains a **single responsibility**.
- [x] I have performed a self-review of my own code.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] All markdown lists in this description strictly use `-` instead of `*`.